### PR TITLE
Add support for GCP connections

### DIFF
--- a/steps/apply/step.sh
+++ b/steps/apply/step.sh
@@ -37,6 +37,12 @@ if [ -n "${AWS}" ]; then
   export AWS_SHARED_CREDENTIALS_FILE=/workspace/.aws/credentials
 fi
 
+GCP=$(ni get -p {.gcp})
+if [ -n "${GCP}" ]; then
+  ni gcp config
+	`ni gcp env`
+fi
+
 DIRECTORY=$(ni get -p {.directory})
 
 GIT=$(ni get -p {.git})

--- a/steps/destroy/step.sh
+++ b/steps/destroy/step.sh
@@ -37,6 +37,12 @@ if [ -n "${AWS}" ]; then
   export AWS_SHARED_CREDENTIALS_FILE=/workspace/.aws/credentials
 fi
 
+GCP=$(ni get -p {.gcp})
+if [ -n "${GCP}" ]; then
+  ni gcp config
+	`ni gcp env`
+fi
+
 DIRECTORY=$(ni get -p {.directory})
 
 GIT=$(ni get -p {.git})

--- a/steps/plan/step.sh
+++ b/steps/plan/step.sh
@@ -37,6 +37,12 @@ if [ -n "${AWS}" ]; then
   export AWS_SHARED_CREDENTIALS_FILE=/workspace/.aws/credentials
 fi
 
+GCP=$(ni get -p {.gcp})
+if [ -n "${GCP}" ]; then
+  ni gcp config
+	`ni gcp env`
+fi
+
 DIRECTORY=$(ni get -p {.directory})
 
 GIT=$(ni get -p {.git})


### PR DESCRIPTION
This PR uses the latest version of `ni` to setup GCP connections for usage during Terraform runs.

**Note:** Some further testing is needed before this can be landed. Just opening it up to communicate the state of the world.