### PR TITLE
Add schema for Terraform steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,13 @@
 
 Integration with Terraform for Puppet Relay.
 
-## External requirements
+## Steps
 
-_TBD_
-
-## Getting started
-
-_TBD_
-
-## Examples
-
-_TBD_
+| Name                     | Description                       |
+|--------------------------|-----------------------------------|
+|[apply](steps/apply/)     | Applies a terraform configuration |
+|[destroy](steps/destroy/) | Runs tf destroy                   |
+|[plan](steps/plan/)       | Outputs an execution plan         |
 
 ## Contributing
 

--- a/steps/apply/spec.schema.json
+++ b/steps/apply/spec.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "properties": {
+    "os": {
+      "type": "object",
+      "description": "Additional packages and commands to run prior to terraform execution",
+      "properties": {
+        "packages": {
+          "type": "array",
+          "description": "list of apk packages to install at container execution time"
+        },
+        "commands": {
+          "type": "array",
+          "description": "List of shell commands to run after packages are installed but before Terrafrom executes"
+        }
+      }
+    },
+    "workspace": {
+      "type": "string",
+      "description": "The name of the Terraform workspace to run (defaults to 'default')"
+    },
+    "credentials": {
+      "type": "string",
+      "description": "Relay secret containing the credentials.json for accessing GCP"
+    },
+    "aws": {
+      "type": "object",
+      "description": "AWS access keys",
+      "properties": {
+        "accessKeyID": {
+          "type": "string",
+          "description": "Access Key ID for the AWS account"
+        },
+        "secretAccessKey": {
+          "type": "string",
+          "description": "The secret key for the AWS account"
+        }
+      },
+      "required": [
+        "accessKeyID",
+        "secretAccessKey"
+      ]
+    },
+    "directory": {
+      "type": "string",
+      "description": "Subdirectory of the git repository containing the Terraform config root"
+    },
+    "plan": {
+      "type": "string",
+      "description": "The contents of a Terraform plan"
+    },
+    "vars": {
+      "type": "object",
+      "description": "A map of variables to set as tfvars"
+    },
+    "backendConfig": {
+      "type": "object",
+      "description": "A map of backend configuration variables to be passed to terraform as -backend-config=key=value"
+    },
+    "git": {
+      "type": "object",
+      "description": "A git repository containing the terraform code to run",
+      "properties": {
+        "ssh_key": {
+          "type": "string",
+          "description": "The SSH key to use when cloning the git repository. You can pass the key  into Relay as a secret."
+        },
+        "known_hosts": {
+          "type": "string",
+          "description": "SSH known hosts file. Pass the contents of the file into Relay as a secr et."
+        },
+        "name": {
+          "type": "string",
+          "description": "A directory name for the git clone"
+        },
+        "branch": {
+          "type": "string",
+          "description": "The git branch to clone"
+        },
+        "repository": {
+          "type": "string",
+          "description": "The git repository URL"
+        }
+      },
+      "required": [
+        "ssh_key",
+        "known_hosts",
+        "name",
+        "repository"
+      ]
+    }
+  }
+}

--- a/steps/apply/spec.schema.json
+++ b/steps/apply/spec.schema.json
@@ -18,15 +18,21 @@
     },
     "workspace": {
       "type": "string",
+      "default": "default",
       "description": "The name of the Terraform workspace to run (defaults to 'default')"
     },
     "credentials": {
-      "type": "string",
-      "description": "Relay secret containing the credentials.json for accessing GCP"
+      "type": "object",
+      "description": "Relay secret containing a base-64 encoded service-account.json file for accessing GCP",
+      "properties" : {
+        "service-account.json": {
+          "type": "string"
+        }
+      }
     },
     "aws": {
       "type": "object",
-      "description": "AWS access keys",
+      "description": "AWS access credentials",
       "properties": {
         "accessKeyID": {
           "type": "string",
@@ -35,11 +41,16 @@
         "secretAccessKey": {
           "type": "string",
           "description": "The secret key for the AWS account"
+        },
+        "region": {
+          "type": "string",
+          "description": "The default AWS region to use"
         }
       },
       "required": [
         "accessKeyID",
-        "secretAccessKey"
+        "secretAccessKey",
+        "region"
       ]
     },
     "directory": {

--- a/steps/apply/step.yaml
+++ b/steps/apply/step.yaml
@@ -11,3 +11,7 @@ build:
   kind: Docker
 publish:
   repository: relaysh/terraform-step-apply
+schemas:
+  spec:
+    source: file
+    file: spec.schema.json

--- a/steps/destroy/spec.schema.json
+++ b/steps/destroy/spec.schema.json
@@ -18,15 +18,21 @@
     },
     "workspace": {
       "type": "string",
+      "default": "default",
       "description": "The name of the Terraform workspace to run (defaults to 'default')"
     },
     "credentials": {
-      "type": "string",
-      "description": "Relay secret containing the credentials.json for accessing GCP"
+      "type": "object",
+      "description": "Relay secret containing a base-64 encoded service-account.json file for accessing GCP",
+      "properties" : {
+        "service-account.json": {
+          "type": "string"
+        }
+      }
     },
     "aws": {
       "type": "object",
-      "description": "AWS access keys",
+      "description": "AWS access credentials",
       "properties": {
         "accessKeyID": {
           "type": "string",
@@ -35,6 +41,10 @@
         "secretAccessKey": {
           "type": "string",
           "description": "The secret key for the AWS account"
+        },
+        "region": {
+          "type": "string",
+          "description": "The default AWS region to use"
         }
       },
       "required": [

--- a/steps/destroy/spec.schema.json
+++ b/steps/destroy/spec.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "properties": {
+    "os": {
+      "type": "object",
+      "description": "Additional packages and commands to run prior to terraform execution",
+      "properties": {
+        "packages": {
+          "type": "array",
+          "description": "list of apk packages to install at container execution time"
+        },
+        "commands": {
+          "type": "array",
+          "description": "List of shell commands to run after packages are installed but before Terrafrom executes"
+        }
+      }
+    },
+    "workspace": {
+      "type": "string",
+      "description": "The name of the Terraform workspace to run (defaults to 'default')"
+    },
+    "credentials": {
+      "type": "string",
+      "description": "Relay secret containing the credentials.json for accessing GCP"
+    },
+    "aws": {
+      "type": "object",
+      "description": "AWS access keys",
+      "properties": {
+        "accessKeyID": {
+          "type": "string",
+          "description": "Access Key ID for the AWS account"
+        },
+        "secretAccessKey": {
+          "type": "string",
+          "description": "The secret key for the AWS account"
+        }
+      },
+      "required": [
+        "accessKeyID",
+        "secretAccessKey"
+      ]
+    },
+    "directory": {
+      "type": "string",
+      "description": "Subdirectory of the git repository containing the Terraform config root"
+    },
+    "vars": {
+      "type": "object",
+      "description": "A map of variables to set as tfvars"
+    },
+    "backendConfig": {
+      "type": "object",
+      "description": "A map of backend configuration variables to be passed to terraform as -backend-config=key=value"
+    },
+    "git": {
+      "type": "object",
+      "description": "A git repository containing the terraform code to run",
+      "properties": {
+        "ssh_key": {
+          "type": "string",
+          "description": "The SSH key to use when cloning the git repository. You can pass the key  into Relay as a secret."
+        },
+        "known_hosts": {
+          "type": "string",
+          "description": "SSH known hosts file. Pass the contents of the file into Relay as a secr et."
+        },
+        "name": {
+          "type": "string",
+          "description": "A directory name for the git clone"
+        },
+        "branch": {
+          "type": "string",
+          "description": "The git branch to clone"
+        },
+        "repository": {
+          "type": "string",
+          "description": "The git repository URL"
+        }
+      },
+      "required": [
+        "ssh_key",
+        "known_hosts",
+        "name",
+        "repository"
+      ]
+    }
+  }
+}

--- a/steps/destroy/step.yaml
+++ b/steps/destroy/step.yaml
@@ -10,3 +10,7 @@ build:
   kind: Docker
 publish:
   repository: relaysh/terraform-step-destroy
+schemas:
+  spec:
+    source: file
+    file: spec.schema.json

--- a/steps/plan/outputs.schema.json
+++ b/steps/plan/outputs.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "properties": {
+    "plan": {
+      "type": "object",
+      "description": "Object containting a base64-encoded Terraform .tfplan",
+      "properties": {
+        "$encoding": {
+          "type": "string",
+          "description": "The encoding of the data field (always base64)"
+        },
+        "data": {
+          "type": "string",
+          "description": "The content of the .tfplan, encoded in the format described by $encoding"
+        }
+      },
+      "required": [ "$encoding", "data" ]
+    },
+    "changed": {
+      "type": "boolean",
+      "description": "Boolean set to true if any resources will be changed by running the plan"
+    }
+  },
+  "required": ["plan"]
+}
+

--- a/steps/plan/outputs.schema.json
+++ b/steps/plan/outputs.schema.json
@@ -3,19 +3,8 @@
   "type": "object",
   "properties": {
     "plan": {
-      "type": "object",
+      "type": "string",
       "description": "Object containting a base64-encoded Terraform .tfplan",
-      "properties": {
-        "$encoding": {
-          "type": "string",
-          "description": "The encoding of the data field (always base64)"
-        },
-        "data": {
-          "type": "string",
-          "description": "The content of the .tfplan, encoded in the format described by $encoding"
-        }
-      },
-      "required": [ "$encoding", "data" ]
     },
     "changed": {
       "type": "boolean",

--- a/steps/plan/outputs.schema.json
+++ b/steps/plan/outputs.schema.json
@@ -4,7 +4,7 @@
   "properties": {
     "plan": {
       "type": "string",
-      "description": "Object containting a base64-encoded Terraform .tfplan",
+      "description": "Terraform plan data to be used to apply this specific plan",
     },
     "changed": {
       "type": "boolean",

--- a/steps/plan/spec.schema.json
+++ b/steps/plan/spec.schema.json
@@ -18,15 +18,21 @@
     },
     "workspace": {
       "type": "string",
+      "default": "default",
       "description": "The name of the Terraform workspace to run (defaults to 'default')"
     },
     "credentials": {
-      "type": "string",
-      "description": "Relay secret containing the credentials.json for accessing GCP"
+      "type": "object",
+      "description": "Relay secret containing a base-64 encoded service-account.json file for accessing GCP",
+      "properties" : {
+        "service-account.json": {
+          "type": "string"
+        }
+      }
     },
     "aws": {
       "type": "object",
-      "description": "AWS access keys",
+      "description": "AWS access credentials",
       "properties": {
         "accessKeyID": {
           "type": "string",
@@ -35,6 +41,10 @@
         "secretAccessKey": {
           "type": "string",
           "description": "The secret key for the AWS account"
+        },
+        "region": {
+          "type": "string",
+          "description": "The default AWS region to use"
         }
       },
       "required": [

--- a/steps/plan/spec.schema.json
+++ b/steps/plan/spec.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "properties": {
+    "os": {
+      "type": "object",
+      "description": "Additional packages and commands to run prior to terraform execution",
+      "properties": {
+        "packages": {
+          "type": "array",
+          "description": "list of apk packages to install at container execution time"
+        },
+        "commands": {
+          "type": "array",
+          "description": "List of shell commands to run after packages are installed but before Terrafrom executes"
+        }
+      }
+    },
+    "workspace": {
+      "type": "string",
+      "description": "The name of the Terraform workspace to run (defaults to 'default')"
+    },
+    "credentials": {
+      "type": "string",
+      "description": "Relay secret containing the credentials.json for accessing GCP"
+    },
+    "aws": {
+      "type": "object",
+      "description": "AWS access keys",
+      "properties": {
+        "accessKeyID": {
+          "type": "string",
+          "description": "Access Key ID for the AWS account"
+        },
+        "secretAccessKey": {
+          "type": "string",
+          "description": "The secret key for the AWS account"
+        }
+      },
+      "required": [
+        "accessKeyID",
+        "secretAccessKey"
+      ]
+    },
+    "directory": {
+      "type": "string",
+      "description": "Subdirectory of the git repository containing the Terraform config root"
+    },
+    "vars": {
+      "type": "object",
+      "description": "A map of variables to set as tfvars"
+    },
+    "backendConfig": {
+      "type": "object",
+      "description": "A map of backend configuration variables to be passed to terraform as -backend-config=key=value"
+    },
+    "git": {
+      "type": "object",
+      "description": "A git repository containing the terraform code to run",
+      "properties": {
+        "ssh_key": {
+          "type": "string",
+          "description": "The SSH key to use when cloning the git repository. You can pass the key  into Relay as a secret."
+        },
+        "known_hosts": {
+          "type": "string",
+          "description": "SSH known hosts file. Pass the contents of the file into Relay as a secr et."
+        },
+        "name": {
+          "type": "string",
+          "description": "A directory name for the git clone"
+        },
+        "branch": {
+          "type": "string",
+          "description": "The git branch to clone"
+        },
+        "repository": {
+          "type": "string",
+          "description": "The git repository URL"
+        }
+      },
+      "required": [
+        "ssh_key",
+        "known_hosts",
+        "name",
+        "repository"
+      ]
+    }
+  }
+}

--- a/steps/plan/step.yaml
+++ b/steps/plan/step.yaml
@@ -4,11 +4,16 @@ name: plan
 version: 1
 summary: Plan a Terraform configuration
 description: |
-  This step will plan the given Terraform module. The binary plan is available
-  as the output `plan`. An indicator of whether there are changes is available
-  as the output `changed`.
+  This step will plan the given Terraform module.
 build:
   apiVersion: build/v1
   kind: Docker
 publish:
   repository: relaysh/terraform-step-plan
+schemas:
+  spec:
+    source: file
+    file: spec.schema.json
+  outputs:
+    source: file
+    file: outputs.schema.json


### PR DESCRIPTION
This adds schema definitions for `spec` for each step.
It adds `outputs` schema only for the `plan` step, since
`destroy` has no outputs and `apply` has an output format
defined by Terraform itself.