### PR TITLE
Add array items type in spec.schema.json

### DIFF
--- a/steps/plan/spec.schema.json
+++ b/steps/plan/spec.schema.json
@@ -8,10 +8,16 @@
       "properties": {
         "packages": {
           "type": "array",
+          "items": {
+            "type": "string"
+          },
           "description": "list of apk packages to install at container execution time"
         },
         "commands": {
           "type": "array",
+          "items": {
+            "type": "string"
+          },
           "description": "List of shell commands to run after packages are installed but before Terrafrom executes"
         }
       }


### PR DESCRIPTION
@ahpook This is what I mentioned in our meeting, where arrays that don't specify the types of their items won't get rendered in the auto-generated form, so if the items are just strings, it'll look like this:

```json
{
  "type": "array",
  "items": {
    "type": "string"
  }
}
```

I think most of the integrations with arrays have item type specified but not all of them. Do you want to search for the others?